### PR TITLE
feat: update formula sha256 `27b9ec6088d75947969127c89e3371d2450d9e816…`

### DIFF
--- a/firestore-type-generator.rb
+++ b/firestore-type-generator.rb
@@ -6,7 +6,8 @@ class FirestoreTypeGenerator < Formula
 
   if OS.mac?
     url "https://github.com/magisystem0408/firestore-type-generator/releases/download/v#{version}/firegen-aarch64-apple-darwin.tar.gz"
-    sha256 "REPLACE_WITH_ACTUAL_SHA256"
+    sha256 "27b9ec6088d75947969127c89e3371d2450d9e8162d4d35f4c800a57c258e660"
+  end
 
   def install
     bin.install "firegen"


### PR DESCRIPTION
This pull request updates the `firestore-type-generator.rb` file to include the correct SHA-256 checksum for the macOS binary of the Firestore Type Generator.

Checksum Update:

* [`firestore-type-generator.rb`](diffhunk://#diff-1c8c0ac7f9c0ab5226d4df750725d62d575f8e01644afbf003eff1d7019ddf58L9-R10): Replaced the placeholder SHA-256 checksum with the actual checksum for the macOS binary.