### PR TITLE
feat: change cli name fitype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 
 [[bin]]
-name = "firegen"
+name = "fitype"
 path = "src/main.rs"
 
 [dependencies]

--- a/fitype.rb
+++ b/fitype.rb
@@ -1,19 +1,19 @@
-class Firegen < Formula
+class Fitype < Formula
   desc "A tool to generate TypeScript types from Firestore schema"
   homepage "https://github.com/magisystem0408/firestore-type-generator"
   version "0.0.1"
   license "MIT"
 
   if OS.mac?
-    url "https://github.com/magisystem0408/firestore-type-generator/releases/download/v#{version}/firegen-aarch64-apple-darwin.tar.gz"
+    url "https://github.com/magisystem0408/firestore-type-generator/releases/download/v#{version}/fitype-aarch64-apple-darwin.tar.gz"
     sha256 "27b9ec6088d75947969127c89e3371d2450d9e8162d4d35f4c800a57c258e660"
   end
 
   def install
-    bin.install "firegen"
+    bin.install "fitype"
   end
 
   test do
-    system "#{bin}/firegen", "--version"
+    system "#{bin}/fitype", "--version"
   end
 end 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 
 #[derive(Parser, Debug)]
-#[command(name="firegen",author, version)]
+#[command(name="fitype",author, version)]
 pub struct Args {
     #[arg(short, long)]
     pub input: String,


### PR DESCRIPTION
This pull request includes changes to rename the project from "firegen" to "fitype". The most important changes include updating the project name in various files and adjusting URLs and commands accordingly.

Project renaming:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L7-R7): Changed the binary name from `firegen` to `fitype`.
* `firestore-type-generator.rb` renamed to `fitype.rb`: Updated the class name, description, URL, and command references from `firegen` to `fitype`.
* [`src/cli.rs`](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL6-R6): Updated the command name from `firegen` to `fitype` in the `Args` struct definition.